### PR TITLE
Bugfix handing over transition matrix to RScore

### DIFF
--- a/RangeShiftR/src/Rinterface.cpp
+++ b/RangeShiftR/src/Rinterface.cpp
@@ -1614,7 +1614,7 @@ int ReadStageStructureR(Rcpp::S4 ParMaster)
 				ss = (float)trmatrix(i - 1, i); // survival prob
 			else
 				ss = (float)trmatrix(i, i);
-			if((i + 2) != matrixsize)
+			if((i + 2) != matrixsize && (i + 1) != matrixsize)
 				dd = (float)trmatrix(i + 1, i); // development prob
 			else
 				dd = 0.0;


### PR DESCRIPTION
 handing over complex stage structure transition matrix had a bug for the last entry causing crashes under linux HPC